### PR TITLE
Fix winner detection and show full hand details

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -233,9 +233,7 @@ function HandResultModal({
             <h3 className="text-xl font-bold text-green-800 mb-2">
               🏆 Winner: {handResult.player_names[handResult.winner]}
             </h3>
-            {handResult.hand_ranks && handResult.hand_ranks[handResult.winner] && (
-              <p className="text-green-700 font-medium">Winning Hand: {handResult.hand_ranks[handResult.winner]}</p>
-            )}
+            {/* Winning hand is no longer shown */}
           </div>
 
           {/* Community Cards */}
@@ -249,41 +247,43 @@ function HandResultModal({
           {/* Results Section */}
           <div className="space-y-3">
             <h4 className="font-bold text-gray-800 text-lg border-b pb-2">Hand Results:</h4>
-            {handResult.payoffs.map((payoff, index) => (
-              <div key={index} className="bg-white p-4 rounded-lg border shadow-sm">
-                <div className="flex justify-between items-start mb-2">
-                  <div className="flex-1">
-                    <span className="font-bold text-lg">{handResult.player_names[index]}</span>
-                    {index === handResult.winner && (
-                      <Badge className="ml-2 bg-yellow-500 text-yellow-900">Winner</Badge>
-                    )}
-                    {handResult.folded && handResult.folded[index] && (
-                      <Badge variant="destructive" className="ml-2">Folded</Badge>
-                    )}
-                  </div>
-                  <div className="text-right">
-                    <div className={`text-xl font-bold ${payoff >= 0 ? "text-green-600" : "text-red-600"}`}> 
-                      {payoff >= 0 ? "+" : ""}
-                      {payoff}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {handResult.payoffs.map((payoff, index) => (
+                <div key={index} className="bg-white p-4 rounded-lg border shadow-sm">
+                  <div className="flex justify-between items-start mb-2">
+                    <div className="flex-1">
+                      <span className="font-bold text-lg">{handResult.player_names[index]}</span>
+                      {index === handResult.winner && (
+                        <Badge className="ml-2 bg-yellow-500 text-yellow-900">Winner</Badge>
+                      )}
+                      {handResult.folded && handResult.folded[index] && (
+                        <Badge variant="destructive" className="ml-2">Folded</Badge>
+                      )}
                     </div>
-                    <div className="text-sm text-gray-500">New Stack: {"$" + handResult.final_stacks[index]}</div>
+                    <div className="text-right">
+                      <div className={`text-xl font-bold ${payoff >= 0 ? "text-green-600" : "text-red-600"}`}>
+                        {payoff >= 0 ? "+" : ""}
+                        {payoff}
+                      </div>
+                      <div className="text-sm text-gray-500">New Stack: {"$" + handResult.final_stacks[index]}</div>
+                    </div>
                   </div>
-                </div>
 
-                {/* Hand Rank Display */}
-                {handResult.hand_ranks && handResult.hand_ranks[index] && (
-                  <div className="mt-2 pt-2 border-t border-gray-200">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="text-sm text-gray-600">Hand:</span>
-                      <span className="text-sm font-medium text-gray-800">{handResult.hand_ranks[index]}</span>
+                  {/* Hand Rank Display */}
+                  {handResult.hand_ranks && handResult.hand_ranks[index] && (
+                    <div className="mt-2 pt-2 border-t border-gray-200">
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="text-sm text-gray-600">Hand:</span>
+                        <span className="text-sm font-medium text-gray-800">{handResult.hand_ranks[index]}</span>
+                      </div>
+                      {handResult.player_hands && handResult.player_hands[index] && (
+                        <CardDisplay cards={handResult.player_hands[index]} />
+                      )}
                     </div>
-                    {handResult.player_hands && handResult.player_hands[index] && (
-                      <CardDisplay cards={handResult.player_hands[index]} />
-                    )}
-                  </div>
-                )}
-              </div>
-            ))}
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
 
           {/* Continue Button */}
@@ -485,7 +485,6 @@ export default function PokerGame() {
       <div className="max-w-6xl mx-auto">
         {/* Game Info Header */}
         <div className="text-center mb-4">
-          <h1 className="text-2xl font-bold text-white mb-2">Texas Hold'em Poker</h1>
           <div className="flex justify-center gap-6 text-white text-sm">
             <div className="flex items-center gap-2">
               <Clock className="w-4 h-4" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,6 +32,9 @@ interface GameState {
     payoffs: number[]
     final_stacks: number[]
     hand_ranks?: string[]
+    community_cards?: string[]
+    player_hands?: string[][]
+    folded?: boolean[]
   }
 }
 
@@ -41,6 +44,9 @@ interface HandResult {
   final_stacks: number[]
   player_names: string[]
   hand_ranks?: string[]
+  community_cards?: string[]
+  player_hands?: string[][]
+  folded?: boolean[]
 }
 
 const SUIT_SYMBOLS = { C: "♣", D: "♦", H: "♥", S: "♠" }
@@ -232,6 +238,14 @@ function HandResultModal({
             )}
           </div>
 
+          {/* Community Cards */}
+          {handResult.community_cards && handResult.community_cards.length > 0 && (
+            <div className="text-center">
+              <h4 className="font-bold text-gray-800 text-lg mb-2">Community Cards</h4>
+              <CardDisplay cards={handResult.community_cards} />
+            </div>
+          )}
+
           {/* Results Section */}
           <div className="space-y-3">
             <h4 className="font-bold text-gray-800 text-lg border-b pb-2">Hand Results:</h4>
@@ -243,9 +257,12 @@ function HandResultModal({
                     {index === handResult.winner && (
                       <Badge className="ml-2 bg-yellow-500 text-yellow-900">Winner</Badge>
                     )}
+                    {handResult.folded && handResult.folded[index] && (
+                      <Badge variant="destructive" className="ml-2">Folded</Badge>
+                    )}
                   </div>
                   <div className="text-right">
-                    <div className={`text-xl font-bold ${payoff >= 0 ? "text-green-600" : "text-red-600"}`}>
+                    <div className={`text-xl font-bold ${payoff >= 0 ? "text-green-600" : "text-red-600"}`}> 
                       {payoff >= 0 ? "+" : ""}
                       {payoff}
                     </div>
@@ -256,10 +273,13 @@ function HandResultModal({
                 {/* Hand Rank Display */}
                 {handResult.hand_ranks && handResult.hand_ranks[index] && (
                   <div className="mt-2 pt-2 border-t border-gray-200">
-                    <div className="flex items-center justify-between">
+                    <div className="flex items-center justify-between mb-2">
                       <span className="text-sm text-gray-600">Hand:</span>
                       <span className="text-sm font-medium text-gray-800">{handResult.hand_ranks[index]}</span>
                     </div>
+                    {handResult.player_hands && handResult.player_hands[index] && (
+                      <CardDisplay cards={handResult.player_hands[index]} />
+                    )}
                   </div>
                 )}
               </div>
@@ -342,6 +362,9 @@ export default function PokerGame() {
           final_stacks: data.hand_results.final_stacks,
           player_names: gameState.players.map((p) => p.name),
           hand_ranks: data.hand_results.hand_ranks || [],
+          community_cards: data.hand_results.community_cards || [],
+          player_hands: data.hand_results.player_hands || [],
+          folded: data.hand_results.folded || [],
         })
       }
 
@@ -377,6 +400,9 @@ export default function PokerGame() {
           final_stacks: data.hand_results.final_stacks,
           player_names: gameState.players.map((p) => p.name),
           hand_ranks: data.hand_results.hand_ranks || [],
+          community_cards: data.hand_results.community_cards || [],
+          player_hands: data.hand_results.player_hands || [],
+          folded: data.hand_results.folded || [],
         })
       }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,7 +220,7 @@ function HandResultModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <Card className="w-[500px] max-w-[90vw] bg-gradient-to-br from-yellow-50 to-orange-50 border-yellow-200 shadow-2xl">
+      <Card className="w-[700px] max-w-[95vw] bg-gradient-to-br from-yellow-50 to-orange-50 border-yellow-200 shadow-2xl">
         <CardHeader className="flex flex-row items-center justify-between pb-4">
           <CardTitle className="text-2xl font-bold text-gray-800">Hand Complete!</CardTitle>
           <Button variant="ghost" size="sm" onClick={onClose}>
@@ -247,7 +247,7 @@ function HandResultModal({
           {/* Results Section */}
           <div className="space-y-3">
             <h4 className="font-bold text-gray-800 text-lg border-b pb-2">Hand Results:</h4>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="grid grid-cols-3 gap-4">
               {handResult.payoffs.map((payoff, index) => (
                 <div key={index} className="bg-white p-4 rounded-lg border shadow-sm">
                   <div className="flex justify-between items-start mb-2">
@@ -278,6 +278,9 @@ function HandResultModal({
                       </div>
                       {handResult.player_hands && handResult.player_hands[index] && (
                         <CardDisplay cards={handResult.player_hands[index]} />
+                      )}
+                      {handResult.folded && handResult.folded[index] && (
+                        <p className="text-center text-sm text-red-600 font-semibold mt-1">Folded</p>
                       )}
                     </div>
                   )}

--- a/scripts/poker_backend.py
+++ b/scripts/poker_backend.py
@@ -251,12 +251,15 @@ def convert_game_state(env, obs: dict, current_player_id: int, ai_last_actions=N
             for i in range(3):
                 hand_rank = get_player_hand_rank(env, i)
                 hand_ranks.append(hand_rank)
-            
+
             hand_results = {
-                "winner": winner if winner is not None else 0,
+                "winner": int(np.argmax(env._last_payoffs)),
                 "payoffs": env._last_payoffs,
                 "final_stacks": [p["stack"] for p in players],
-                "hand_ranks": hand_ranks
+                "hand_ranks": hand_ranks,
+                "community_cards": [format_card(c) for c in env.game.public_cards],
+                "player_hands": [[format_card(c) for c in pl.hand] for pl in env.game.players],
+                "folded": [getattr(pl, "folded", False) for pl in env.game.players],
             }
         
         return GameState(
@@ -345,10 +348,13 @@ async def start_game():
 
             global last_hand_results
             last_hand_results = {
-                "winner": detect_winner(env) if detect_winner(env) is not None else 0,
+                "winner": int(np.argmax(payoffs_list)),
                 "payoffs": payoffs_list,
                 "final_stacks": [p.stack for p in env.game.players],
                 "hand_ranks": hand_ranks,
+                "community_cards": [format_card(c) for c in env.game.public_cards],
+                "player_hands": [[format_card(c) for c in p.hand] for p in env.game.players],
+                "folded": [getattr(p, "folded", False) for p in env.game.players],
             }
 
             if not any(p.stack <= 0 for p in env.game.players):
@@ -539,10 +545,13 @@ async def make_action(request: ActionRequest):
 
             global last_hand_results
             last_hand_results = {
-                "winner": detect_winner(env) if detect_winner(env) is not None else 0,
+                "winner": int(np.argmax(payoffs_list)),
                 "payoffs": payoffs_list,
                 "final_stacks": [p.stack for p in env.game.players],
                 "hand_ranks": hand_ranks,
+                "community_cards": [format_card(c) for c in env.game.public_cards],
+                "player_hands": [[format_card(c) for c in p.hand] for p in env.game.players],
+                "folded": [getattr(p, "folded", False) for p in env.game.players],
             }
 
             # 新しいハンドの開始（誰も破産していない場合）


### PR DESCRIPTION
## Summary
- include community cards, player hands, and folded info in game state
- display community cards and player hands in Hand Result modal
- show folded badge and correct winner when human folds

## Testing
- `python -m py_compile scripts/poker_backend.py`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686a8bb9da0c8323b3f23bde5b702bbf