### PR TITLE
Improve hand result modal layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,7 +220,7 @@ function HandResultModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-      <Card className="w-[700px] max-w-[95vw] bg-gradient-to-br from-yellow-50 to-orange-50 border-yellow-200 shadow-2xl">
+      <Card className="w-[700px] max-w-[95vw] max-h-[80vh] overflow-y-auto bg-gradient-to-br from-yellow-50 to-orange-50 border-yellow-200 shadow-2xl">
         <CardHeader className="flex flex-row items-center justify-between pb-4">
           <CardTitle className="text-2xl font-bold text-gray-800">Hand Complete!</CardTitle>
           <Button variant="ghost" size="sm" onClick={onClose}>
@@ -247,9 +247,9 @@ function HandResultModal({
           {/* Results Section */}
           <div className="space-y-3">
             <h4 className="font-bold text-gray-800 text-lg border-b pb-2">Hand Results:</h4>
-            <div className="grid grid-cols-3 gap-4">
+            <div className="flex justify-between gap-4">
               {handResult.payoffs.map((payoff, index) => (
-                <div key={index} className="bg-white p-4 rounded-lg border shadow-sm">
+                <div key={index} className="flex-1 bg-white p-4 rounded-lg border shadow-sm">
                   <div className="flex justify-between items-start mb-2">
                     <div className="flex-1">
                       <span className="font-bold text-lg">{handResult.player_names[index]}</span>
@@ -271,18 +271,18 @@ function HandResultModal({
 
                   {/* Hand Rank Display */}
                   {handResult.hand_ranks && handResult.hand_ranks[index] && (
-                    <div className="mt-2 pt-2 border-t border-gray-200">
-                      <div className="flex items-center justify-between mb-2">
+                    <div className="mt-2 pt-2 border-t border-gray-200 space-y-2">
+                      <div className="flex items-center justify-between">
                         <span className="text-sm text-gray-600">Hand:</span>
                         <span className="text-sm font-medium text-gray-800">{handResult.hand_ranks[index]}</span>
                       </div>
                       {handResult.player_hands && handResult.player_hands[index] && (
                         <CardDisplay cards={handResult.player_hands[index]} />
                       )}
-                      {handResult.folded && handResult.folded[index] && (
-                        <p className="text-center text-sm text-red-600 font-semibold mt-1">Folded</p>
-                      )}
                     </div>
+                  )}
+                  {handResult.folded && handResult.folded[index] && (
+                    <p className="mt-2 text-center text-sm text-red-600 font-semibold">Folded</p>
                   )}
                 </div>
               ))}


### PR DESCRIPTION
## Summary
- keep the hand result modal shorter with scrolling
- display results for each player side by side
- always show `Folded` label when a player folded

## Testing
- `npx next lint` *(fails: needs next@15.3.5 to install)*

------
https://chatgpt.com/codex/tasks/task_e_686a9b666c488323931f369534b4d7ec