### PR TITLE
Fix pot display

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -498,7 +498,7 @@ export default function PokerGame() {
             </div>
             <div className="flex items-center gap-2">
               <Coins className="w-4 h-4" />
-              <span>Pot: {"$" + gameState.pot}</span>
+              <span>Pot: {"$" + gameState.pot / 2}</span>
             </div>
             <span>Current: {gameState.players?.[gameState.current_player]?.name}</span>
           </div>
@@ -518,7 +518,7 @@ export default function PokerGame() {
             </div>
             {/* Pot visualization */}
             <div className="mt-3 flex justify-center">
-              <ChipStack amount={gameState.pot} size="lg" />
+              <ChipStack amount={gameState.pot / 2} size="lg" />
             </div>
           </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -572,7 +572,7 @@ export default function PokerGame() {
                             </div>
                             <div>
                               <div className="text-gray-600 mb-1">Bet</div>
-                              <ChipStack amount={player.in_chips} size="sm" />
+                              <ChipStack amount={player.in_chips / 2} size="sm" />
                             </div>
                           </div>
                           {/* Folded バッジ */}


### PR DESCRIPTION
## Summary
- correct pot display by halving the amount in the demo UI

## Testing
- `pnpm run lint` *(fails: How would you like to configure ESLint?)*
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e29445af48323ad95c4371398c030